### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,12 @@ interface LinearGradient {
 
 ### Font
 
-| 参数    | 说明     | 类型   | 默认值     | 备注 |
-| ------- | -------- | ------ | ---------- | ---- |
-| size    | 字体大小 | number | 10         | -    |
-| style   | 字体样式 | string | normal     | -    |
-| variant | 字体变体 | string | normal     | -    |
-| weight  | 字体粗细 | string | normal     | -    |
-| family  | 字体系列 | string | sans-serif | -    |
+| 参数   | 说明     | 类型   | 默认值     | 备注 |
+| ------ | -------- | ------ | ---------- | ---- |
+| size   | 字体大小 | number | 10         | -    |
+| style  | 字体样式 | string | normal     | -    |
+| weight | 字体粗细 | string | normal     | -    |
+| family | 字体系列 | string | sans-serif | -    |
 
 ### TextAlign
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsu-canvas/renderer",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "some cesium utils",
   "repository": "git@github.com:VitaTsui/canvas-renderer.git",
   "author": "VitaHsu <vitahsu7@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "hsu-utils": "^0.0.45"
+    "hsu-utils": "^0.0.46"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsu-canvas/renderer",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "some cesium utils",
   "repository": "git@github.com:VitaTsui/canvas-renderer.git",
   "author": "VitaHsu <vitahsu7@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "hsu-utils": "^0.0.45"
+    "hsu-utils": "^0.0.47"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "hsu-utils": "^0.0.47"
+    "hsu-utils": "^0.0.48"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "hsu-utils": "^0.0.46"
+    "hsu-utils": "^0.0.45"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsu-canvas/renderer",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "some cesium utils",
   "repository": "git@github.com:VitaTsui/canvas-renderer.git",
   "author": "VitaHsu <vitahsu7@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsu-canvas/renderer",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "some cesium utils",
   "repository": "git@github.com:VitaTsui/canvas-renderer.git",
   "author": "VitaHsu <vitahsu7@gmail.com>",

--- a/src/ImageGraphics/index.ts
+++ b/src/ImageGraphics/index.ts
@@ -1,18 +1,19 @@
 import loadImage from '../utils/loadImage'
 
-type Padding = number | [number, number] | [number, number, number, number]
+// 基础类型
+export type Padding = number | [number, number] | [number, number, number, number]
+export type Direction = 'vertical' | 'horizontal'
+export type ImgAlign = 'start' | 'center' | 'end'
 
-type Direction = 'vertical' | 'horizontal'
-
-type ImgAlign = 'start' | 'center' | 'end'
-
-interface ImageItem {
+// 图片项接口
+export interface ImageItem {
   url: string
   width?: number
   height?: number
   zIndex?: number
 }
 
+// 内部使用的图片元素接口（不导出）
 interface ImageElement {
   image: HTMLImageElement
   width: number
@@ -124,9 +125,7 @@ function drawImg(options: DrawImgOptions) {
   }
 }
 
-/**
- * 绘制 ImageGraphics
- */
+// 主配置接口
 export interface ImageGraphicsOptions {
   imgs: string | ImageItem | Array<string | ImageItem>
   padding?: Padding

--- a/src/TextGraphics/drawBorder.ts
+++ b/src/TextGraphics/drawBorder.ts
@@ -1,4 +1,4 @@
-type Radius = number | [number, number, number, number]
+import type { Radius } from './index'
 
 export interface BorderStyle {
   color?: string
@@ -6,7 +6,7 @@ export interface BorderStyle {
   radius?: Radius
 }
 
-interface DrawBorderOptions {
+export interface DrawBorderOptions {
   ctx: CanvasRenderingContext2D
   width: number
   height: number

--- a/src/TextGraphics/drawCtx.ts
+++ b/src/TextGraphics/drawCtx.ts
@@ -1,23 +1,5 @@
 import loadImage from '../utils/loadImage'
-
-type Fill = 'ctx' | 'img'
-
-type Radius = number | [number, number, number, number]
-
-type Direction = 'vertical' | 'horizontal'
-
-interface LinearGradient {
-  [key: number]: string
-}
-
-export interface BackgroundStyle {
-  color?: string | LinearGradient
-  colorDirection?: Direction
-  image?: string
-  imageSize?: [string, string] | string
-  imagePosition?: [number, number] | number
-  imageFill?: Fill
-}
+import type { BackgroundStyle, Radius } from './index'
 
 export interface DrawCtxOptions {
   ctx: CanvasRenderingContext2D

--- a/src/TextGraphics/drawText.ts
+++ b/src/TextGraphics/drawText.ts
@@ -1,38 +1,6 @@
 import { deepCopy, get_string_size } from 'hsu-utils'
-
-type TextAlign = 'left' | 'center' | 'right'
-
-interface LinearGradient {
-  [key: number]: string
-}
-
-interface TextShadowStyle {
-  color?: string
-  blur?: number
-  offsetX?: number
-  offsetY?: number
-}
-
-interface TextBorderStyle {
-  color?: string
-  width?: number
-}
-
-interface Font {
-  size?: number
-  style?: string
-  weight?: string
-  family?: string
-}
-
-export interface FontStyle {
-  font?: Font
-  color?: string | LinearGradient
-  textAlign?: TextAlign
-  letterSpacing?: number
-  border?: TextBorderStyle
-  shadow?: TextShadowStyle | TextShadowStyle[]
-}
+import loadFont from '../utils/loadFont'
+import type { FontStyle, TextAlign, LinearGradient, Font } from './index'
 
 function _calculateLeft(maxTextLength: number, textLenth: number, textAlign: TextAlign) {
   let _left = 0
@@ -98,13 +66,9 @@ export default async function drawText(options: DrawTextOptions) {
   const { color: borderColor = '#000', width: borderWidth = 0 } = border
   const { style = 'normal', weight = 'normal', size = 10, family: fontFamily = 'sans-serif' } = font
 
-  await document.fonts.load(`${style} ${weight} ${size}px ${fontFamily}`)
+  await loadFont({ ctx, font, text: text[0] || '' })
 
   ctx.font = `${style} ${weight} ${size}px ${fontFamily}`
-
-  ctx.fillText(text[0] || '', -999, -999)
-  await new Promise(requestAnimationFrame)
-
   ctx.textAlign = 'left'
   ctx.textBaseline = 'middle'
   ctx.strokeStyle = borderColor

--- a/src/TextGraphics/drawText.ts
+++ b/src/TextGraphics/drawText.ts
@@ -21,7 +21,6 @@ interface TextBorderStyle {
 interface Font {
   size?: number
   style?: string
-  variant?: string
   weight?: string
   family?: string
 }
@@ -97,11 +96,15 @@ export default async function drawText(options: DrawTextOptions) {
   const { ctx, text, maxTextLength, fontStyle = {}, top = 0, left = 0, rowGap = 0 } = options
   const { color = '#000', textAlign = 'center', font = {}, border = {}, shadow, letterSpacing = 0 } = fontStyle
   const { color: borderColor = '#000', width: borderWidth = 0 } = border
-  const { style = 'normal', variant = 'normal', weight = 'normal', size = 10, family: fontFamily = 'sans-serif' } = font
+  const { style = 'normal', weight = 'normal', size = 10, family: fontFamily = 'sans-serif' } = font
 
-  await document.fonts.load(`${style} ${variant} ${weight} ${size}px ${fontFamily}`)
+  await document.fonts.load(`${style} ${weight} ${size}px ${fontFamily}`)
 
-  ctx.font = `${style} ${variant} ${weight} ${size}px ${fontFamily}`
+  ctx.font = `${style} ${weight} ${size}px ${fontFamily}`
+
+  ctx.fillText('', -999, -999)
+  await new Promise(requestAnimationFrame)
+
   ctx.textAlign = 'left'
   ctx.textBaseline = 'middle'
   ctx.strokeStyle = borderColor

--- a/src/TextGraphics/drawText.ts
+++ b/src/TextGraphics/drawText.ts
@@ -102,7 +102,7 @@ export default async function drawText(options: DrawTextOptions) {
 
   ctx.font = `${style} ${weight} ${size}px ${fontFamily}`
 
-  ctx.fillText('', -999, -999)
+  ctx.fillText(text[0] || '', -999, -999)
   await new Promise(requestAnimationFrame)
 
   ctx.textAlign = 'left'

--- a/src/TextGraphics/index.ts
+++ b/src/TextGraphics/index.ts
@@ -1,15 +1,72 @@
 import { deepCopy, get_string_size } from 'hsu-utils'
 import loadImage from '../utils/loadImage'
-import drawCtx, { BackgroundStyle } from './drawCtx'
-import drawBorder, { BorderStyle } from './drawBorder'
-import drawText, { FontStyle } from './drawText'
+import drawCtx from './drawCtx'
+import drawBorder from './drawBorder'
+import drawText from './drawText'
 
-type Padding = number | [number, number] | [number, number, number, number]
+// 基础类型
+export type Padding = number | [number, number] | [number, number, number, number]
+export type Size = number | 'auto' | 'bgImg'
+export type Align = 'top' | 'center' | 'bottom'
+export type Radius = number | [number, number, number, number]
+export type Direction = 'vertical' | 'horizontal'
+export type Fill = 'ctx' | 'img'
 
-type Size = number | 'auto' | 'bgImg'
+// 渐变类型
+export interface LinearGradient {
+  [key: number]: string
+}
 
-type Align = 'top' | 'center' | 'bottom'
+// 文本相关类型
+export type TextAlign = 'left' | 'center' | 'right'
 
+export interface TextShadowStyle {
+  color?: string
+  blur?: number
+  offsetX?: number
+  offsetY?: number
+}
+
+export interface TextBorderStyle {
+  color?: string
+  width?: number
+}
+
+export interface Font {
+  size?: number
+  style?: string
+  weight?: string
+  family?: string
+}
+
+// 背景样式
+export interface BackgroundStyle {
+  color?: string | LinearGradient
+  colorDirection?: Direction
+  image?: string
+  imageSize?: [string, string] | string
+  imagePosition?: [number, number] | number
+  imageFill?: Fill
+}
+
+// 边框样式
+export interface BorderStyle {
+  color?: string
+  width?: number
+  radius?: Radius
+}
+
+// 字体样式
+export interface FontStyle {
+  font?: Font
+  color?: string | LinearGradient
+  textAlign?: TextAlign
+  letterSpacing?: number
+  border?: TextBorderStyle
+  shadow?: TextShadowStyle | TextShadowStyle[]
+}
+
+// 主配置接口
 export interface TextGraphicsOptions {
   content?: string | string[]
   borderStyle?: BorderStyle

--- a/src/TextGraphics/index.ts
+++ b/src/TextGraphics/index.ts
@@ -37,7 +37,6 @@ export default async function TextGraphics(options: TextGraphicsOptions): Promis
     font = {
       size: 10,
       style: 'normal',
-      variant: 'normal',
       weight: 'normal',
       family: 'sans-serif'
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,36 @@ import TextGraphics from './TextGraphics'
 import ImageGraphics from './ImageGraphics'
 export { TextGraphics, ImageGraphics }
 
-import { TextGraphicsOptions } from './TextGraphics'
-import { ImageGraphicsOptions } from './ImageGraphics'
-export type { TextGraphicsOptions, ImageGraphicsOptions }
-
 import loadImage from './utils/loadImage'
 export { loadImage }
+
+import loadFont from './utils/loadFont'
+export { loadFont }
+
+// 导出 TextGraphics 相关类型
+export type {
+  TextGraphicsOptions,
+  Padding as TextPadding,
+  Size,
+  Align,
+  Radius,
+  Direction as TextDirection,
+  Fill,
+  LinearGradient,
+  TextAlign,
+  TextShadowStyle,
+  TextBorderStyle,
+  Font,
+  BackgroundStyle,
+  BorderStyle,
+  FontStyle
+} from './TextGraphics'
+
+// 导出 ImageGraphics 相关类型
+export type {
+  ImageGraphicsOptions,
+  ImgAlign,
+  ImageItem,
+  Padding as ImagePadding,
+  Direction as ImageDirection
+} from './ImageGraphics'

--- a/src/utils/loadFont.ts
+++ b/src/utils/loadFont.ts
@@ -2,7 +2,7 @@ interface Font {
   style?: string
   weight?: string
   size?: number
-  fontFamily?: string
+  family?: string
 }
 
 export interface LoadFontOptions {
@@ -13,13 +13,13 @@ export interface LoadFontOptions {
 
 export default async function loadFont(options: LoadFontOptions) {
   const { ctx, font = {}, text } = options
-  const { style = 'normal', weight = 'normal', size = 10, fontFamily = 'sans-serif' } = font
+  const { style = 'normal', weight = 'normal', size = 10, family = 'sans-serif' } = font
 
-  await document.fonts.load(`${style} ${weight} ${size}px ${fontFamily}`)
+  await document.fonts.load(`${style} ${weight} ${size}px ${family}`)
 
   const _ctx = ctx || (document.createElement('canvas').getContext('2d') as CanvasRenderingContext2D)
 
-  _ctx.font = `${style} ${weight} ${size}px ${fontFamily}`
+  _ctx.font = `${style} ${weight} ${size}px ${family}`
   _ctx.fillText(text || '', -999, -999)
 
   await new Promise(requestAnimationFrame)

--- a/src/utils/loadFont.ts
+++ b/src/utils/loadFont.ts
@@ -1,0 +1,26 @@
+interface Font {
+  style?: string
+  weight?: string
+  size?: number
+  fontFamily?: string
+}
+
+export interface LoadFontOptions {
+  ctx?: CanvasRenderingContext2D
+  font?: Font
+  text?: string
+}
+
+export default async function loadFont(options: LoadFontOptions) {
+  const { ctx, font = {}, text } = options
+  const { style = 'normal', weight = 'normal', size = 10, fontFamily = 'sans-serif' } = font
+
+  await document.fonts.load(`${style} ${weight} ${size}px ${fontFamily}`)
+
+  const _ctx = ctx || (document.createElement('canvas').getContext('2d') as CanvasRenderingContext2D)
+
+  _ctx.font = `${style} ${weight} ${size}px ${fontFamily}`
+  _ctx.fillText(text || '', -999, -999)
+
+  await new Promise(requestAnimationFrame)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,10 +1737,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hsu-utils@^0.0.46:
-  version "0.0.46"
-  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.46.tgz#d779373c723ad8146c6d8e44cc1a13811a11c55d"
-  integrity sha512-X3rVrRJg+xQwbnoY6g1lm/u5YVTjBbvb3n5DhliSTeKp6ZHQGo/HED3IveL7ph0JQsczbXJzWTME39wA4iSPfw==
+hsu-utils@^0.0.45:
+  version "0.0.45"
+  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.45.tgz#22fe05368acf870e9724cad69c6598bf6c193ada"
+  integrity sha512-MRdqGRyV9c4/11WXqVz4NP0BkRzZ4Eud9uqy7nPs7KvXodYgbm2Ya1+ExnnsNs6rskhDk1wSL5V+godGbjpCYw==
   dependencies:
     pdfjs-dist "2.13.216"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,10 +1737,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hsu-utils@^0.0.47:
-  version "0.0.47"
-  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.47.tgz#686b9352a339491e608185750f6f180d98ddf110"
-  integrity sha512-CbfG2bTOLihQjD+Atykzg5UCDUqX4gp8m9TVEfLiKqybOHhY5osgBbBwu0sN6oKyn/IBNNN8SGsje8L7xqmXYQ==
+hsu-utils@^0.0.48:
+  version "0.0.48"
+  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.48.tgz#fd417bb8b9b25dea3818ba1dfa3626f1daeb5ba1"
+  integrity sha512-3F2J1CW8x7ztEPJpgavo0I+pp5TJSnaZlDLEeenAtou5LqVQFw8WZ0CO8mmdjtDbvEOgPurCTUOpnbH/0ewxqA==
   dependencies:
     pdfjs-dist "2.13.216"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,10 +1737,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hsu-utils@^0.0.45:
-  version "0.0.45"
-  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.45.tgz#22fe05368acf870e9724cad69c6598bf6c193ada"
-  integrity sha512-MRdqGRyV9c4/11WXqVz4NP0BkRzZ4Eud9uqy7nPs7KvXodYgbm2Ya1+ExnnsNs6rskhDk1wSL5V+godGbjpCYw==
+hsu-utils@^0.0.47:
+  version "0.0.47"
+  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.47.tgz#686b9352a339491e608185750f6f180d98ddf110"
+  integrity sha512-CbfG2bTOLihQjD+Atykzg5UCDUqX4gp8m9TVEfLiKqybOHhY5osgBbBwu0sN6oKyn/IBNNN8SGsje8L7xqmXYQ==
   dependencies:
     pdfjs-dist "2.13.216"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,10 +1737,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hsu-utils@^0.0.45:
-  version "0.0.45"
-  resolved "https://registry.yarnpkg.com/hsu-utils/-/hsu-utils-0.0.45.tgz#22fe05368acf870e9724cad69c6598bf6c193ada"
-  integrity sha512-MRdqGRyV9c4/11WXqVz4NP0BkRzZ4Eud9uqy7nPs7KvXodYgbm2Ya1+ExnnsNs6rskhDk1wSL5V+godGbjpCYw==
+hsu-utils@^0.0.46:
+  version "0.0.46"
+  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.46.tgz#d779373c723ad8146c6d8e44cc1a13811a11c55d"
+  integrity sha512-X3rVrRJg+xQwbnoY6g1lm/u5YVTjBbvb3n5DhliSTeKp6ZHQGo/HED3IveL7ph0JQsczbXJzWTME39wA4iSPfw==
   dependencies:
     pdfjs-dist "2.13.216"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `loadFont` for reliable text rendering, centralizes/exports types, updates README, and bumps package/deps.
> 
> - **Text rendering**:
>   - Use new `utils/loadFont` in `TextGraphics/drawText.ts` to preload fonts; remove `variant` from `Font` and adjust `ctx.font` string.
>   - Refactor `drawCtx.ts` and `drawBorder.ts` to import shared types; export `DrawBorderOptions`.
> - **Types/API**:
>   - Centralize and export core types in `TextGraphics/index.ts` and `ImageGraphics/index.ts` (e.g., `Padding`, `Radius`, `Font`, `BackgroundStyle`, `ImageItem`, etc.).
>   - Re-export types and `loadFont` from root `src/index.ts`.
> - **Docs**:
>   - Update README `Font` table (remove `variant`, tidy headers) and reflect type definitions.
> - **Package**:
>   - Bump version to `0.0.12`; update dependency `hsu-utils` to `^0.0.48`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efb59bc791b703469e066ee5e5e9b5f112ff8e69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->