### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ yarn add @hsu-canvas/renderer
 - [**TextGraphics**](#textgraphics) 文本渲染
 - [**ImageGraphics**](#imagegraphics) 图片渲染
 - [**loadImage**](#loadimage) 异步加载图片并缓存
+- [**loadFont**](#loadfont) 预加载字体，避免首次渲染闪烁
 
 ## TextGraphics
 
@@ -143,15 +144,15 @@ interface LinearGradient {
 
 ### ImageGraphicsOptions
 
-| 参数      | 说明        | 类型                                                            | 默认值   | 备注                  |
-| --------- | ----------- | --------------------------------------------------------------- | -------- | --------------------- |
-| imgs      | 图片        | string \| [ImageItem](#imageitem) \| Array<string \| ImageItem> | -        | 必填                  |
-| padding   | 内边距      | [Padding](#paddingimage)                                        | 0        | -                     |
-| direction | 布局样式    | [Direction](#directionimage)                                    | vertical | -                     |
-| gap       | 间隔        | number                                                          | 0        | -                     |
-| imgAlign  | 对齐方式    | [ImgAlign](#imgalign)                                           | center   | -                     |
-| width     | canvas 宽度 | number \| 'auto'                                                | auto     | auto 时为图片最大宽度 |
-| height    | canvas 高度 | number \| 'auto'                                                | auto     | auto 时为图片最大高度 |
+| 参数 | 说明 | 类型 | 默认值 | 备注 |
+| --- | --- | --- | --- | --- |
+| imgs | 图片 | string \| [ImageItem](#imageitem) \| Array<string \| ImageItem> | - | 必填 |
+| padding | 内边距 | [Padding](#paddingimage) | 0 | - |
+| direction | 布局样式 | [Direction](#directionimage) | vertical | - |
+| gap | 间隔 | number | 0 | - |
+| imgAlign | 对齐方式 | [ImgAlign](#imgalign) | center | - |
+| width | canvas 宽度 | number \| 'auto' | auto | auto 时：vertical 为「图片最大宽度 + padding + 垂直排列额外 gap」，horizontal 为「所有图片宽度之和 + padding + 水平排列额外 gap」 |
+| height | canvas 高度 | number \| 'auto' | auto | auto 时：horizontal 为「图片最大高度 + padding + 水平排列额外 gap」，vertical 为「所有图片高度之和 + padding + 垂直排列额外 gap」 |
 
 ### ImageItem
 
@@ -179,6 +180,40 @@ interface LinearGradient {
 | 参数 | 说明     | 类型   | 默认值 | 备注 |
 | ---- | -------- | ------ | ------ | ---- |
 | url  | 图片地址 | string | -      | 必填 |
+
+## loadFont
+
+用于在绘制文字前预加载字体，避免首次渲染时出现闪烁或回退字体。
+
+> 函数签名（TS）：`loadFont(options: LoadFontOptions): Promise<void>`
+
+| 参数 | 说明 | 类型 | 默认值 | 备注 |
+| --- | --- | --- | --- | --- |
+| options | 字体加载配置项 | [LoadFontOptions](#loadfontoptions) | - | ctx 不传时内部会创建临时 canvas 进行一次离屏文字绘制触发 |
+
+其中 `Font` 结构与 [TextGraphics](#font) 中的 `Font` 一致：
+
+```ts
+interface Font {
+  size?: number // 字体大小（px），默认 10
+  style?: string // 字体样式，默认 'normal'
+  weight?: string // 字体粗细，默认 'normal'
+  family?: string // 字体系列，默认 'sans-serif'
+}
+```
+
+### LoadFontOptions
+
+```ts
+interface LoadFontOptions {
+  /** 要设置字体并进行预渲染的 2D 上下文，不传则内部创建临时 canvas */
+  ctx?: CanvasRenderingContext2D
+  /** 字体配置，不传则使用默认字体 */
+  font?: Font
+  /** 用于触发字体渲染的一段文字，通常可以传入实际要渲染的文本 */
+  text?: string
+}
+```
 
 ## License
 

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -14,7 +14,7 @@
     "noEmit": false,
     "jsx": "react",
     "newLine": "lf",
-    "removeComments": true,
+    "removeComments": false,
   },
   "include": ["../src/**/*.ts", "../src/**/*.tsx"],
   "exclude": ["node_modules", "../src/**/__tests__"]

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -42,10 +42,16 @@ const config = {
     minimizer: devMode
       ? []
       : [
-          // 压缩js代码
-          // webpack v5 使用内置的TerserJSPlugin替代UglifyJsPlugin，因为UglifyJsPlugin不支持ES6
+          // 压缩 js 代码，但保留注释（例如头部 Banner、JSDoc 等）
+          // webpack v5 使用内置的 TerserJSPlugin 替代 UglifyJsPlugin，因为 UglifyJsPlugin 不支持 ES6
           new TerserJSPlugin({
-            parallel: true // 使用多进程并行运行
+            parallel: true, // 使用多进程并行运行
+            extractComments: false, // 不额外抽取到 .LICENSE.txt 文件，直接保留在 bundle 中
+            terserOptions: {
+              format: {
+                comments: 'all', // 保留所有注释，如果只想保留以 /*! 开头的，可以改为 'some'
+              },
+            },
           }),
         ]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hsu-canvas/renderer",
-  "version": "0.0.12",
+  "version": "0.0.14",
   "description": "some cesium utils",
   "repository": "git@github.com:VitaTsui/canvas-renderer.git",
   "author": "VitaHsu <vitahsu7@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "hsu-utils": "^0.0.48"
+    "hsu-utils": "^0.0.54"
   }
 }

--- a/src/ImageGraphics/index.ts
+++ b/src/ImageGraphics/index.ts
@@ -5,11 +5,17 @@ export type Padding = number | [number, number] | [number, number, number, numbe
 export type Direction = 'vertical' | 'horizontal'
 export type ImgAlign = 'start' | 'center' | 'end'
 
-// 图片项接口
+/**
+ * 图片项配置
+ */
 export interface ImageItem {
+  /** 图片地址 */
   url: string
+  /** 绘制宽度，不传则使用图片本身宽度 */
   width?: number
+  /** 绘制高度，不传则使用图片本身高度 */
   height?: number
+  /** 层级，数值越大越靠上 */
   zIndex?: number
 }
 
@@ -22,9 +28,7 @@ interface ImageElement {
   index: number
 }
 
-/**
- * 获取最大图片宽度
- */
+/** 获取最大图片宽度 / 水平总宽度（包含所有图片宽度） */
 function get_img_maxWidth(images: ImageElement[], direction: Direction) {
   let width = 0
 
@@ -41,9 +45,7 @@ function get_img_maxWidth(images: ImageElement[], direction: Direction) {
   return width
 }
 
-/**
- * 获取最大图片高度
- */
+/** 获取最大图片高度 / 垂直总高度（包含所有图片高度） */
 function get_img_maxHeight(images: ImageElement[], direction: Direction) {
   let height = 0
 
@@ -61,17 +63,26 @@ function get_img_maxHeight(images: ImageElement[], direction: Direction) {
 }
 
 /**
- * 绘制图片
+ * 绘制图片到画布
  */
 interface DrawImgOptions {
+  /** 绘制使用的 2D 上下文 */
   ctx: CanvasRenderingContext2D
+  /** 最大可用宽度（不包含 padding），用于水平对齐计算 */
   maxWidth?: number
+  /** 最大可用高度（不包含 padding），用于垂直对齐计算 */
   maxHeight?: number
+  /** 已经加载好的图片元素列表 */
   images: ImageElement[]
+  /** 内容距画布顶部的偏移量 */
   top?: number
+  /** 内容距画布左侧的偏移量 */
   left?: number
+  /** 图片之间的间距 */
   gap?: number
+  /** 布局方向，水平或垂直 */
   direction?: Direction
+  /** 单行/单列内部的图片对齐方式 */
   imgAlign?: ImgAlign
 }
 function drawImg(options: DrawImgOptions) {
@@ -125,16 +136,37 @@ function drawImg(options: DrawImgOptions) {
   }
 }
 
-// 主配置接口
+/**
+ * `ImageGraphics` 主配置
+ */
 export interface ImageGraphicsOptions {
+  /**
+   * 图片资源：
+   * - 字符串：图片地址
+   * - `ImageItem`：带尺寸与层级的图片配置
+   * - 数组：可混合传入
+   */
   imgs: string | ImageItem | Array<string | ImageItem>
+  /** 画布内边距，上右下左，支持简写 */
   padding?: Padding
+  /** 图片排列方向 */
   direction?: Direction
+  /** 图片之间的间距 */
   gap?: number
+  /** 每行/列中图片的对齐方式 */
   imgAlign?: ImgAlign
+  /** 画布宽度，`auto` 表示根据图片自动计算 */
   width?: number | 'auto'
+  /** 画布高度，`auto` 表示根据图片自动计算 */
   height?: number | 'auto'
 }
+
+/**
+ * 根据配置生成图片排布的画布
+ *
+ * @param options 图片排布及画布相关配置
+ * @returns 已绘制完成图片的 `HTMLCanvasElement`
+ */
 export default async function ImageGraphics(options: ImageGraphicsOptions) {
   const {
     imgs,

--- a/src/TextGraphics/drawBorder.ts
+++ b/src/TextGraphics/drawBorder.ts
@@ -1,18 +1,36 @@
 import type { Radius } from './index'
 
+/**
+ * 边框样式配置
+ */
 export interface BorderStyle {
+  /** 边框颜色 */
   color?: string
+  /** 边框线宽 */
   width?: number
+  /** 边框圆角，支持单值或 [lt, rt, rb, lb] */
   radius?: Radius
 }
 
+/**
+ * 边框绘制配置
+ */
 export interface DrawBorderOptions {
+  /** 用于绘制边框的 2D 上下文 */
   ctx: CanvasRenderingContext2D
+  /** 绘制区域宽度 */
   width: number
+  /** 绘制区域高度 */
   height: number
+  /** 边框样式 */
   borderStyle?: BorderStyle
 }
 
+/**
+ * 根据配置在画布上绘制矩形圆角边框
+ *
+ * @param options 边框绘制参数
+ */
 export default function drawBorder(options: DrawBorderOptions) {
   const { ctx, width, height, borderStyle = {} } = options
   const { color: borderColor, width: borderWidth = 0, radius: borderRadius = 0 } = borderStyle

--- a/src/TextGraphics/drawCtx.ts
+++ b/src/TextGraphics/drawCtx.ts
@@ -1,14 +1,27 @@
 import loadImage from '../utils/loadImage'
 import type { BackgroundStyle, Radius } from './index'
 
+/**
+ * 绘制背景上下文配置
+ */
 export interface DrawCtxOptions {
+  /** 用于绘制背景的 2D 上下文 */
   ctx: CanvasRenderingContext2D
+  /** 背景样式（颜色 / 渐变 / 图片等），不传则不绘制背景 */
   backgroundStyle?: BackgroundStyle
+  /** 背景圆角，支持单值或 [lt, rt, rb, lb] */
   radius?: Radius
+  /** 绘制区域宽度 */
   width: number
+  /** 绘制区域高度 */
   height: number
 }
 
+/**
+ * 按配置在指定区域内绘制背景（纯色 / 渐变 / 图片），并支持圆角裁剪
+ *
+ * @param options 背景绘制参数
+ */
 export default async function drawCtx(options: DrawCtxOptions) {
   const { ctx, width, height, radius = 0, backgroundStyle = {} } = options
   const {

--- a/src/TextGraphics/drawText.ts
+++ b/src/TextGraphics/drawText.ts
@@ -2,6 +2,13 @@ import { deepCopy, get_string_size } from 'hsu-utils'
 import loadFont from '../utils/loadFont'
 import type { FontStyle, TextAlign, LinearGradient, Font } from './index'
 
+/**
+ * 根据最大行宽与对齐方式，计算当前行文本的起始 x 坐标偏移
+ *
+ * @param maxTextLength 可用的最大文本宽度
+ * @param textLenth 当前行文本实际宽度
+ * @param textAlign 文本对齐方式
+ */
 function _calculateLeft(maxTextLength: number, textLenth: number, textAlign: TextAlign) {
   let _left = 0
 
@@ -15,15 +22,27 @@ function _calculateLeft(maxTextLength: number, textLenth: number, textAlign: Tex
   return _left
 }
 
+/**
+ * 单行文本绘制配置
+ */
 interface DrawRowText {
+  /** 2D 绘制上下文 */
   ctx: CanvasRenderingContext2D
+  /** 要绘制的文本内容（单行） */
   text: string
+  /** 文本起始 x 坐标 */
   left: number
+  /** 文本基线位置 y 坐标 */
   top: number
+  /** 字号，单位 px */
   size: number
+  /** 描边线宽 */
   borderWidth: number
+  /** 字符间距 */
   letterSpacing: number
+  /** 文本颜色，可以是纯色或线性渐变 */
   color: string | LinearGradient
+  /** 字体配置 */
   font: Font
 }
 function drawRowText(options: DrawRowText) {
@@ -51,15 +70,34 @@ function drawRowText(options: DrawRowText) {
   }
 }
 
+/**
+ * 多行文本绘制配置
+ */
 interface DrawTextOptions {
+  /** 2D 绘制上下文 */
   ctx: CanvasRenderingContext2D
+  /** 文本内容（多行数组，每个元素为一行） */
   text: string[]
+  /** 单行可用的最大宽度，影响对齐与截断 */
   maxTextLength?: number
+  /** 文本样式配置（颜色、字体、描边、阴影等） */
   fontStyle?: FontStyle
+  /** 文本整体相对画布顶部的偏移量 */
   top?: number
+  /** 文本整体相对画布左侧的偏移量 */
   left?: number
+  /** 行间距 */
   rowGap?: number
 }
+
+/**
+ * 在给定画布上下文中绘制多行文本，包括：
+ * - 文本对齐（left / center / right）
+ * - 字间距、行间距
+ * - 渐变文字、描边、阴影等效果
+ *
+ * @param options 文本绘制参数
+ */
 export default async function drawText(options: DrawTextOptions) {
   const { ctx, text, maxTextLength, fontStyle = {}, top = 0, left = 0, rowGap = 0 } = options
   const { color = '#000', textAlign = 'center', font = {}, border = {}, shadow, letterSpacing = 0 } = fontStyle

--- a/src/TextGraphics/index.ts
+++ b/src/TextGraphics/index.ts
@@ -20,64 +20,108 @@ export interface LinearGradient {
 // 文本相关类型
 export type TextAlign = 'left' | 'center' | 'right'
 
+/** 文本阴影样式 */
 export interface TextShadowStyle {
+  /** 阴影颜色 */
   color?: string
+  /** 阴影模糊半径 */
   blur?: number
+  /** 阴影 x 方向偏移 */
   offsetX?: number
+  /** 阴影 y 方向偏移 */
   offsetY?: number
 }
 
+/** 描边样式 */
 export interface TextBorderStyle {
+  /** 描边颜色 */
   color?: string
+  /** 描边线宽 */
   width?: number
 }
 
+/** 字体配置 */
 export interface Font {
+  /** 字号，单位 px */
   size?: number
+  /** 字体样式，例如 normal / italic */
   style?: string
+  /** 字重，例如 normal / bold */
   weight?: string
+  /** 字体族名称，例如 sans-serif / Arial */
   family?: string
 }
 
-// 背景样式
+/** 背景样式 */
 export interface BackgroundStyle {
+  /** 背景颜色，可以是纯色或线性渐变 */
   color?: string | LinearGradient
+  /** 渐变方向 */
   colorDirection?: Direction
+  /** 背景图片地址 */
   image?: string
+  /** 背景图片尺寸，支持百分比和绝对值 */
   imageSize?: [string, string] | string
+  /** 背景图片位置，支持 [x, y] 或 单值 */
   imagePosition?: [number, number] | number
+  /** 背景图片填充方式：填满画布或按图片原尺寸 */
   imageFill?: Fill
 }
 
-// 边框样式
+/** 边框样式 */
 export interface BorderStyle {
+  /** 边框颜色 */
   color?: string
+  /** 边框线宽 */
   width?: number
+  /** 边框圆角 */
   radius?: Radius
 }
 
-// 字体样式
+/** 文本字体样式 */
 export interface FontStyle {
+  /** 字体配置 */
   font?: Font
+  /** 文本颜色，可以是纯色或线性渐变 */
   color?: string | LinearGradient
+  /** 文本对齐方式（相对于可用宽度） */
   textAlign?: TextAlign
+  /** 字符间距 */
   letterSpacing?: number
+  /** 文本描边样式 */
   border?: TextBorderStyle
+  /** 文本阴影，可传单个或数组以实现多重阴影 */
   shadow?: TextShadowStyle | TextShadowStyle[]
 }
 
-// 主配置接口
+/**
+ * `TextGraphics` 主配置
+ */
 export interface TextGraphicsOptions {
+  /** 文本内容，单行或多行数组 */
   content?: string | string[]
+  /** 边框样式 */
   borderStyle?: BorderStyle
+  /** 背景样式 */
   backgroundStyle?: BackgroundStyle
+  /** 文本字体及颜色样式 */
   fontStyle?: FontStyle
+  /** 文本与边框/背景之间的内边距（含边框） */
   padding?: Padding
+  /** 画布尺寸：数字为固定值，`auto` 为根据文本计算，`bgImg` 为跟随背景图尺寸 */
   size?: Size | [Size, Size]
+  /** 文本在固定高度中的垂直对齐方式 */
   align?: Align
+  /** 行间距 */
   rowGap?: number
 }
 
+/**
+ * 根据文本、背景、边框等配置生成文字画布
+ *
+ * @param options 文本图形配置
+ * @returns 已绘制完成内容的 `HTMLCanvasElement`
+ */
 export default async function TextGraphics(options: TextGraphicsOptions): Promise<HTMLCanvasElement> {
   const {
     content,

--- a/src/utils/loadFont.ts
+++ b/src/utils/loadFont.ts
@@ -1,16 +1,32 @@
+/**
+ * 字体配置
+ */
 interface Font {
+  /** 字体样式，例如 normal / italic */
   style?: string
+  /** 字重，例如 normal / bold / 100~900 */
   weight?: string
+  /** 字号，单位 px */
   size?: number
+  /** 字体族名称，例如 sans-serif / Arial */
   family?: string
 }
 
+/**
+ * 加载字体的配置项
+ */
 export interface LoadFontOptions {
+  /** 要设置字体并进行预渲染的 2D 上下文，不传则内部创建临时 canvas */
   ctx?: CanvasRenderingContext2D
+  /** 字体配置，不传则使用默认字体 */
   font?: Font
+  /** 用于触发字体渲染的一段文字，通常可以传入实际要渲染的文本 */
   text?: string
 }
 
+/**
+ * 预加载指定字体，确保后续绘制文字时不会出现闪烁或样式错误
+ */
 export default async function loadFont(options: LoadFontOptions) {
   const { ctx, font = {}, text } = options
   const { style = 'normal', weight = 'normal', size = 10, family = 'sans-serif' } = font

--- a/src/utils/loadImage.ts
+++ b/src/utils/loadImage.ts
@@ -1,9 +1,18 @@
-// 图片阻塞请求缓存
+// 图片阻塞请求缓存：用于记录进行中的图片加载 Promise，避免重复请求同一资源
 const imagePromiseCache: { [key: string]: Promise<HTMLImageElement> | undefined } = {}
 
-// 图片缓存
+// 图片缓存：记录已成功加载完成的图片实例
 const imageCache: { [key: string]: HTMLImageElement } = {}
 
+/**
+ * 加载图片并做缓存
+ *
+ * - 相同 URL 的图片只会真正请求一次
+ * - 后续重复调用会直接复用缓存的 Image 对象或进行中的 Promise
+ *
+ * @param url 图片地址
+ * @returns 解析为 `HTMLImageElement` 的 Promise
+ */
 export default async function loadImage(url: string) {
   // 如果图片已经请求过了，则直接返回缓存
   if (imageCache[url]) return imageCache[url]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1381,6 +1381,11 @@ data-urls@^4.0.0:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^12.0.0"
 
+dayjs@^1.11.19:
+  version "1.11.19"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.19.tgz#15dc98e854bb43917f12021806af897c58ae2938"
+  integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
+
 debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
@@ -1737,11 +1742,12 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hsu-utils@^0.0.48:
-  version "0.0.48"
-  resolved "https://registry.npmjs.org/hsu-utils/-/hsu-utils-0.0.48.tgz#fd417bb8b9b25dea3818ba1dfa3626f1daeb5ba1"
-  integrity sha512-3F2J1CW8x7ztEPJpgavo0I+pp5TJSnaZlDLEeenAtou5LqVQFw8WZ0CO8mmdjtDbvEOgPurCTUOpnbH/0ewxqA==
+hsu-utils@^0.0.54:
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/hsu-utils/-/hsu-utils-0.0.54.tgz#2b1546db55bfe2f68e23171eaeb35fee07889acd"
+  integrity sha512-L1I0LWl/9V31lWiWF+z3nnVg1P3wh55dSwV1C0lpXrzNj2O8Q51EBAYzKgcpHuqLJuqOxzFfB3N5/Q5/RqhoHw==
   dependencies:
+    dayjs "^1.11.19"
     pdfjs-dist "2.13.216"
 
 html-encoding-sniffer@^3.0.0:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes canvas output sizing for horizontally/vertically laid out images and adds a font preloading step before text rendering, which can alter rendered dimensions/timing. Build output also changes by retaining comments/banners in compiled bundles.
> 
> **Overview**
> Adds a new `loadFont` utility (and README docs) that preloads a specified font via `document.fonts.load` and triggers an offscreen draw; `TextGraphics` now calls this before drawing text to reduce first-render font fallback/flicker.
> 
> Fixes `ImageGraphics` auto-sizing to compute *total* width/height for horizontal/vertical layouts (instead of max-only) and updates docs accordingly, affecting canvas dimensions when multiple images are rendered with gaps/padding.
> 
> Adjusts build output to preserve comments/banners (TypeScript `removeComments: false` and Terser configured to keep comments and not extract them), and bumps package version plus `hsu-utils` dependency (bringing new transitive deps in `yarn.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 057a0fc38fca2d4faa6481b8a260adf2729553e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->